### PR TITLE
fix: multiple bug fixes across invite flow, character system, and startup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,55 @@
+# D&D Book Environment Configuration
+#
+# Copy this file to .env and customize the values
+# cp .env.example .env
+#
+# REQUIRED variables are marked with [REQUIRED]
+# OPTIONAL variables have sensible defaults
+
+# ============================================
+# REQUIRED: Database Configuration
+# ============================================
+POSTGRES_USER=dndbook_user
+POSTGRES_PASSWORD=dndbook_dev_password
+POSTGRES_DB=dndbook_db
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+
+# ============================================
+# REQUIRED: Security Keys
+# ============================================
+# Generate secure keys: python3 -c "import secrets; print(secrets.token_hex(32))"
+SECRET_KEY=a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890
+JWT_SECRET_KEY=f0e1d2c3b4a5f0e1d2c3b4a5f0e1d2c3b4a5f0e1d2c3b4a5f0e1d2c3b4a5f0e1
+
+# ============================================
+# OPTIONAL: Application Settings
+# ============================================
+# Admin password (default: admin123)
+ADMIN_PASSWORD=admin123
+
+# Mock data for development (default: false)
+MOCK_DATA=false
+
+# Upload settings
+UPLOAD_FOLDER=uploads
+MAX_CONTENT_LENGTH=16777216
+
+# Pagination
+POSTS_PER_PAGE=10
+
+# ============================================
+# OPTIONAL: Frontend Settings
+# ============================================
+# API URL for frontend (default: http://localhost:5000)
+VITE_API_URL=http://localhost:5000
+
+# Frontend mock data (default: false)
+VITE_MOCK_DATA=false
+
+# Available languages (default: en,it,de,es,fr)
+VITE_AVAILABLE_LOCALES=en,it,de,es,fr
+
+# Frontend pagination
+VITE_POSTS_PER_PAGE=10
+VITE_POST_PREVIEW_LIMIT=200

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 # REQUIRED: Database Configuration
 # ============================================
 POSTGRES_USER=dndbook_user
-POSTGRES_PASSWORD=change-this-password [REQUIRED]
+POSTGRES_PASSWORD=dndbook_dev_password
 POSTGRES_DB=dndbook_db
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
@@ -19,8 +19,8 @@ POSTGRES_PORT=5432
 # REQUIRED: Security Keys
 # ============================================
 # Generate secure keys: python3 -c "import secrets; print(secrets.token_hex(32))"
-SECRET_KEY=change-this-secret-key [REQUIRED]
-JWT_SECRET_KEY=change-this-jwt-secret-key [REQUIRED]
+SECRET_KEY=a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890
+JWT_SECRET_KEY=f0e1d2c3b4a5f0e1d2c3b4a5f0e1d2c3b4a5f0e1d2c3b4a5f0e1d2c3b4a5f0e1
 
 # ============================================
 # OPTIONAL: Application Settings

--- a/be/.env
+++ b/be/.env
@@ -18,7 +18,7 @@
 # These are REQUIRED for standalone mode (not inherited from root)
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
-DATABASE_URL=postgresql://dndbook_user:dndbook_dev_password@localhost:5432/dndbook_db
+DATABASE_URL=postgresql+psycopg://dndbook_user:dndbook_dev_password@localhost:5432/dndbook_db
 
 # Optional Overrides
 # Uncomment and modify these only if you need different values than ../env:

--- a/be/.env
+++ b/be/.env
@@ -1,0 +1,38 @@
+# Backend-Specific Environment Variables
+#
+# IMPORTANT: This file is loaded AFTER ../env (root .env)
+# Most configuration should be in ../env - use this only for backend-specific overrides
+#
+# Setup:
+#   1. Ensure ../env exists with shared configuration (POSTGRES_USER, SECRET_KEY, etc.)
+#   2. cp be/.env.example be/.env (optional - only if you need overrides)
+#   3. Edit be/.env with backend-specific values
+#   4. Run: ./run-standalone.sh
+#
+# The script will:
+#   1. Load ../env first (shared configuration)
+#   2. Load be/.env second (overrides)
+#   3. Validate all required variables are present
+
+# Database Configuration (Backend-specific)
+# These are REQUIRED for standalone mode (not inherited from root)
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+DATABASE_URL=postgresql://dndbook_user:dndbook_dev_password@localhost:5432/dndbook_db
+
+# Optional Overrides
+# Uncomment and modify these only if you need different values than ../env:
+
+# Application Configuration
+# SECRET_KEY=backend-specific-secret-key
+# JWT_SECRET_KEY=backend-specific-jwt-secret-key
+
+# Admin User
+# ADMIN_PASSWORD=backend-specific-admin-password
+
+# Upload Configuration
+# UPLOAD_FOLDER=uploads
+# MAX_CONTENT_LENGTH=16777216
+
+# Pagination
+# POSTS_PER_PAGE=10

--- a/be/.env.example
+++ b/be/.env.example
@@ -18,7 +18,7 @@
 # These are REQUIRED for standalone mode (not inherited from root)
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
-DATABASE_URL=postgresql://dndbook_user:dndbook_password@localhost:5432/dndbook_db
+DATABASE_URL=postgresql://dndbook_user:dndbook_dev_password@localhost:5432/dndbook_db
 
 # Optional Overrides
 # Uncomment and modify these only if you need different values than ../env:

--- a/be/.env.example
+++ b/be/.env.example
@@ -18,7 +18,7 @@
 # These are REQUIRED for standalone mode (not inherited from root)
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
-DATABASE_URL=postgresql://dndbook_user:dndbook_dev_password@localhost:5432/dndbook_db
+DATABASE_URL=postgresql+psycopg://dndbook_user:dndbook_dev_password@localhost:5432/dndbook_db
 
 # Optional Overrides
 # Uncomment and modify these only if you need different values than ../env:

--- a/be/app/__init__.py
+++ b/be/app/__init__.py
@@ -17,7 +17,7 @@ load_dotenv()
 
 db = SQLAlchemy()
 migrate = Migrate()
-socketio = SocketIO(cors_allowed_origins="*")
+socketio = SocketIO(cors_allowed_origins="*", async_mode='threading')
 
 
 def create_app():

--- a/be/app/controllers/campaigns_controller.py
+++ b/be/app/controllers/campaigns_controller.py
@@ -227,3 +227,13 @@ def cancel_invite(current_user, campaign_id, invite_id):
         return jsonify({'message': 'Invite cancelled successfully'}), 200
     except ValueError as e:
         return jsonify({'error': str(e)}), 400
+
+
+@bp.route('/<int:campaign_id>/members/<int:user_id>/remind', methods=['POST'])
+@token_required
+def send_character_reminder(current_user, campaign_id, user_id):
+    try:
+        CampaignsService.send_character_reminder(campaign_id, user_id, current_user)
+        return jsonify({'message': 'Reminder sent'}), 200
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 403

--- a/be/app/controllers/characters_controller.py
+++ b/be/app/controllers/characters_controller.py
@@ -235,7 +235,7 @@ def assign_character(current_user, campaign_id, character_id):
         - 404: Campaign or character not found
     """
     data = request.get_json()
-    user_id = data.get('user_id', current_user.id) if data else current_user.id
+    user_id = (data.get('user_id') or current_user.id) if data else current_user.id
     
     try:
         character = CharactersService.assign_character_to_user(

--- a/be/app/controllers/user_controller.py
+++ b/be/app/controllers/user_controller.py
@@ -31,12 +31,14 @@ def update_profile(current_user):
         return jsonify({'error': 'No data provided'}), 400
 
     try:
-        user = UserService.update_profile(
-            user_id=current_user.id,
-            nickname=data.get('nickname'),
-            biography=data.get('biography'),
-            avatar_url=data.get('avatar_url')
-        )
+        kwargs = {
+            'user_id': current_user.id,
+            'nickname': data.get('nickname'),
+            'biography': data.get('biography'),
+        }
+        if 'avatar_url' in data:
+            kwargs['avatar_url'] = data['avatar_url']
+        user = UserService.update_profile(**kwargs)
         return jsonify({
             'message': 'Profile updated successfully',
             'user': user.to_dict()

--- a/be/app/models/campaign.py
+++ b/be/app/models/campaign.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from app import db
+from app.models.campaign_members import CampaignMembers
 
 
 class Campaign(db.Model):
@@ -19,6 +20,7 @@ class Campaign(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
+    members = db.relationship('User', secondary=CampaignMembers, lazy='dynamic')
     posts = db.relationship('Post', backref='campaign', lazy=True, cascade='all, delete-orphan')
     characters = db.relationship('Character', backref='campaign', lazy=True, cascade='all, delete-orphan')
 

--- a/be/app/models/campaign.py
+++ b/be/app/models/campaign.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from app import db
-from app.models.campaign_members import CampaignMembers
 
 
 class Campaign(db.Model):
@@ -20,7 +19,6 @@ class Campaign(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 
-    members = db.relationship('User', secondary=CampaignMembers, lazy='dynamic')
     posts = db.relationship('Post', backref='campaign', lazy=True, cascade='all, delete-orphan')
     characters = db.relationship('Character', backref='campaign', lazy=True, cascade='all, delete-orphan')
 

--- a/be/app/models/notification.py
+++ b/be/app/models/notification.py
@@ -3,7 +3,7 @@ from app import db
 
 class Notification(db.Model):
     __tablename__ = 'notifications'
-    
+
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
     campaign_id = db.Column(db.Integer, db.ForeignKey('campaigns.id'), nullable=True)
@@ -12,6 +12,5 @@ class Notification(db.Model):
     message = db.Column(db.Text, nullable=False)
     related_post_id = db.Column(db.Integer, db.ForeignKey('posts.id'), nullable=True)
     related_comment_id = db.Column(db.Integer, db.ForeignKey('comments.id'), nullable=True)
+    related_invite_id = db.Column(db.Integer, db.ForeignKey('campaign_invites.id', ondelete='CASCADE'), nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow, nullable=False)
-
-

--- a/be/app/services/campaigns_service.py
+++ b/be/app/services/campaigns_service.py
@@ -3,7 +3,8 @@
 from sqlalchemy import and_
 
 from app import db
-from app.models import Campaign, CampaignInvite, CampaignMembers
+from app.models import Campaign, CampaignInvite, CampaignMembers, User, Notification
+from app.events.socketio_events import send_notification
 
 
 class CampaignsService:
@@ -263,3 +264,36 @@ class CampaignsService:
 
         db.session.delete(invite)
         db.session.commit()
+
+    @staticmethod
+    def send_character_reminder(campaign_id, user_id, requester):
+        campaign = Campaign.query.get_or_404(campaign_id)
+
+        if campaign.owner_id != requester.id:
+            raise ValueError('Only the campaign owner can send reminders')
+
+        user = User.query.get_or_404(user_id)
+
+        is_member = db.session.execute(
+            db.select(CampaignMembers).where(
+                and_(
+                    CampaignMembers.c.user_id == user_id,
+                    CampaignMembers.c.campaign_id == campaign_id
+                )
+            )
+        ).first()
+
+        if not is_member:
+            raise ValueError('User is not a member of this campaign')
+
+        notification = Notification(
+            user_id=user_id,
+            campaign_id=campaign_id,
+            notification_type='character_reminder',
+            title=f'Character reminder: {campaign.name}',
+            message=f'{requester.username} is reminding you to pick a character for "{campaign.name}".'
+        )
+        db.session.add(notification)
+        db.session.commit()
+
+        send_notification(user_id)

--- a/be/app/services/campaigns_service.py
+++ b/be/app/services/campaigns_service.py
@@ -60,6 +60,10 @@ class CampaignsService:
         )
 
         db.session.add(campaign)
+        db.session.flush()
+
+        stmt = CampaignMembers.insert().values(user_id=user.id, campaign_id=campaign.id)
+        db.session.execute(stmt)
         db.session.commit()
 
         return campaign
@@ -174,7 +178,13 @@ class CampaignsService:
         if campaign.owner_id != user.id and not is_member:
             raise ValueError('Unauthorized')
 
-        members = [{'id': m.id, 'username': m.username, 'email': m.email} for m in campaign.members.all()]
+        owner = User.query.get(campaign.owner_id)
+        member_ids_seen = {owner.id}
+        members = [{'id': owner.id, 'username': owner.username, 'email': owner.email}]
+        for m in campaign.members.all():
+            if m.id not in member_ids_seen:
+                member_ids_seen.add(m.id)
+                members.append({'id': m.id, 'username': m.username, 'email': m.email})
 
         pending_invites = []
         if campaign.owner_id == user.id:

--- a/be/app/services/characters_service.py
+++ b/be/app/services/characters_service.py
@@ -71,11 +71,16 @@ class CharactersService:
         """
         campaign = Campaign.query.get_or_404(campaign_id)
 
-        if campaign.owner_id != user.id:
-            raise ValueError('Only campaign owner can create characters')
+        is_member = campaign.members.filter_by(id=user.id).first() is not None
+        if campaign.owner_id != user.id and not is_member:
+            raise ValueError('Unauthorized')
 
         if is_predefined and campaign.owner_id != user.id:
             raise ValueError('Only campaign owner can create predefined characters')
+
+        if not is_predefined and campaign.owner_id != user.id:
+            if campaign.character_creation_mode not in ('free', 'optional'):
+                raise ValueError('Only campaign owner can create characters in this campaign')
 
         if not name or not race or not character_class:
             raise ValueError('Name, race, and class are required')

--- a/be/app/services/characters_service.py
+++ b/be/app/services/characters_service.py
@@ -87,6 +87,10 @@ class CharactersService:
 
         image_url = CharactersService._save_character_image(image_file, campaign_id) if image_file else None
 
+        assigned_to_user_id = None
+        if not is_predefined and campaign.owner_id != user.id:
+            assigned_to_user_id = user.id
+
         character = Character(
             campaign_id=campaign_id,
             name=name,
@@ -94,7 +98,8 @@ class CharactersService:
             character_class=character_class,
             description=description,
             image_url=image_url,
-            is_predefined=is_predefined
+            is_predefined=is_predefined,
+            assigned_to_user_id=assigned_to_user_id
         )
 
         db.session.add(character)

--- a/be/app/services/invites_service.py
+++ b/be/app/services/invites_service.py
@@ -84,7 +84,7 @@ class InvitesService:
             'player_username': user.username
         })
 
-        return campaign.to_dict()
+        return campaign
 
     @staticmethod
     def reject_invite(invite_id, user):
@@ -185,7 +185,7 @@ class InvitesService:
                 notification_type='invite',
                 title=f'Campaign invite: {campaign.name}',
                 message=f'{inviter.username} invited you to join the campaign "{campaign.name}".',
-                related_post_id=None
+                related_invite_id=invite.id
             )
             db.session.add(notification)
 

--- a/be/app/services/notifications_service.py
+++ b/be/app/services/notifications_service.py
@@ -34,6 +34,7 @@ class NotificationsService:
                 'message': notif.message,
                 'related_post_id': notif.related_post_id,
                 'related_comment_id': notif.related_comment_id,
+                'related_invite_id': notif.related_invite_id,
                 'created_at': notif.created_at.isoformat() + 'Z' if notif.created_at else None
             })
 

--- a/be/app/services/user_service.py
+++ b/be/app/services/user_service.py
@@ -3,12 +3,14 @@
 from app import db
 from app.models import User
 
+_UNSET = object()
+
 
 class UserService:
     """Service for handling user profile business logic."""
 
     @staticmethod
-    def update_profile(user_id, nickname=None, biography=None, avatar_url=None):
+    def update_profile(user_id, nickname=None, biography=None, avatar_url=_UNSET):
         """
         Update user profile information.
 
@@ -16,7 +18,8 @@ class UserService:
             user_id (int): The ID of the user to update
             nickname (str, optional): New nickname
             biography (str, optional): New biography
-            avatar_url (str, optional): New avatar URL (None to remove avatar)
+            avatar_url (str | None, optional): New avatar URL; pass None to remove avatar,
+                omit entirely to leave it unchanged
 
         Returns:
             User: Updated user object
@@ -32,8 +35,8 @@ class UserService:
             user.nickname = nickname
         if biography is not None:
             user.biography = biography
-        # Allow setting avatar_url to None to remove avatar
-        user.avatar_url = avatar_url
+        if avatar_url is not _UNSET:
+            user.avatar_url = avatar_url
 
         db.session.commit()
         return user

--- a/be/docker-entrypoint-initdb.d/init-db.sql
+++ b/be/docker-entrypoint-initdb.d/init-db.sql
@@ -109,6 +109,7 @@ CREATE TABLE IF NOT EXISTS notifications (
     message TEXT NOT NULL,
     related_post_id INTEGER REFERENCES posts(id) ON DELETE CASCADE,
     related_comment_id INTEGER REFERENCES comments(id) ON DELETE CASCADE,
+    related_invite_id INTEGER REFERENCES campaign_invites(id) ON DELETE CASCADE,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -120,13 +121,27 @@ CREATE TABLE IF NOT EXISTS notifications (
 DO $$
 BEGIN
     IF NOT EXISTS (
-        SELECT 1 FROM information_schema.columns 
+        SELECT 1 FROM information_schema.columns
         WHERE table_name = 'notifications' AND column_name = 'related_comment_id'
     ) THEN
         ALTER TABLE notifications ADD COLUMN related_comment_id INTEGER REFERENCES comments(id);
         RAISE NOTICE 'Added related_comment_id column to notifications table';
     ELSE
         RAISE NOTICE 'related_comment_id column already exists in notifications table';
+    END IF;
+END $$;
+
+-- Add related_invite_id to notifications if it doesn't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'notifications' AND column_name = 'related_invite_id'
+    ) THEN
+        ALTER TABLE notifications ADD COLUMN related_invite_id INTEGER REFERENCES campaign_invites(id) ON DELETE CASCADE;
+        RAISE NOTICE 'Added related_invite_id column to notifications table';
+    ELSE
+        RAISE NOTICE 'related_invite_id column already exists in notifications table';
     END IF;
 END $$;
 

--- a/be/main.py
+++ b/be/main.py
@@ -13,4 +13,4 @@ if __name__ == '__main__':
             print(f"Migration warning: {e}")
             print("Continuing with application startup...")
 
-    socketio.run(flask_app, host='0.0.0.0', port=5000, debug=False)
+    socketio.run(flask_app, host='0.0.0.0', port=5000, debug=False, allow_unsafe_werkzeug=True)

--- a/be/main.py
+++ b/be/main.py
@@ -1,7 +1,3 @@
-import eventlet
-
-eventlet.monkey_patch()
-
 from app import create_app, socketio
 
 flask_app = create_app()

--- a/be/migrations/versions/add_related_invite_id_to_notifications.py
+++ b/be/migrations/versions/add_related_invite_id_to_notifications.py
@@ -1,0 +1,37 @@
+"""Add related_invite_id to notifications
+
+Revision ID: add_related_invite_id_to_notifications
+Revises: add_user_profile_fields
+Create Date: 2026-05-17
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = 'add_related_invite_id_to_notifications'
+down_revision = 'add_user_profile_fields'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'notifications' AND column_name = 'related_invite_id'
+            ) THEN
+                ALTER TABLE notifications
+                    ADD COLUMN related_invite_id INTEGER
+                    REFERENCES campaign_invites(id) ON DELETE CASCADE;
+            END IF;
+        END $$;
+    """)
+
+
+def downgrade():
+    op.execute("""
+        ALTER TABLE notifications DROP COLUMN IF EXISTS related_invite_id;
+    """)

--- a/be/requirements.txt
+++ b/be/requirements.txt
@@ -5,7 +5,7 @@ Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.5
 python-dotenv==1.0.0
 eventlet==0.35.2
-psycopg2-binary==2.9.9
+psycopg[binary]>=3.1
 PyJWT==2.8.0
 Werkzeug==3.0.1
 pytest==7.4.3

--- a/be/requirements.txt
+++ b/be/requirements.txt
@@ -4,7 +4,6 @@ Flask-SocketIO==5.3.6
 Flask-SQLAlchemy==3.1.1
 Flask-Migrate==4.0.5
 python-dotenv==1.0.0
-eventlet==0.35.2
 psycopg[binary]>=3.1
 PyJWT==2.8.0
 Werkzeug==3.0.1

--- a/be/run-standalone.sh
+++ b/be/run-standalone.sh
@@ -120,6 +120,7 @@ else
         -e POSTGRES_DB=$POSTGRES_DB \
         -p $POSTGRES_PORT:5432 \
         -v $POSTGRES_VOLUME:/var/lib/postgresql/data \
+        -v "$(pwd)/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d:ro" \
         postgres:16-alpine
     echo "✓ PostgreSQL container created and started"
     echo "⏳ Waiting for PostgreSQL to be ready..."

--- a/be/tests/services/test_characters_service.py
+++ b/be/tests/services/test_characters_service.py
@@ -168,8 +168,8 @@ def test_create_character_success(app):
 
 def test_create_character_unauthorized(app):
     """GIVEN a campaign owned by one user
-    WHEN another user attempts to create a character
-    THEN creation should be denied with 'Only campaign owner can create characters' error
+    WHEN a non-member user attempts to create a character
+    THEN creation should be denied with 'Unauthorized' error
     """
     with app.app_context():
         # GIVEN
@@ -192,7 +192,7 @@ def test_create_character_unauthorized(app):
         db.session.commit()
         
         # WHEN & THEN
-        with pytest.raises(ValueError, match='Only campaign owner can create characters'):
+        with pytest.raises(ValueError, match='Unauthorized'):
             CharactersService.create_character(
                 campaign_id=campaign.id,
                 user=other,

--- a/be/tests/services/test_invites_service.py
+++ b/be/tests/services/test_invites_service.py
@@ -105,9 +105,9 @@ def test_accept_invite_success(app):
         # WHEN
         result = InvitesService.accept_invite(invite.id, invitee)
         
-        # THEN
-        assert result['id'] == campaign.id
-        assert result['name'] == 'Test Campaign'
+        # THEN — accept_invite returns the Campaign model object
+        assert result.id == campaign.id
+        assert result.name == 'Test Campaign'
         
         deleted_invite = CampaignInvite.query.get(invite.id)
         assert deleted_invite is None

--- a/docker-compose.standalone.yaml
+++ b/docker-compose.standalone.yaml
@@ -25,7 +25,7 @@ services:
       - "5000:5000"
     environment:
       - FLASK_ENV=production
-      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      - DATABASE_URL=postgresql+psycopg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - SECRET_KEY=${SECRET_KEY}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}

--- a/docker-compose.yaml.template
+++ b/docker-compose.yaml.template
@@ -6,7 +6,7 @@ services:
     restart: always
     environment:
       - FLASK_ENV=production
-      - DATABASE_URL=postgresql://${DNDBOOK_DB_USER}:${DNDBOOK_DB_PASS}@shared_postgres:5432/${DNDBOOK_DB_NAME}
+      - DATABASE_URL=postgresql+psycopg://${DNDBOOK_DB_USER}:${DNDBOOK_DB_PASS}@shared_postgres:5432/${DNDBOOK_DB_NAME}
       - SECRET_KEY=${SECRET_KEY}
       - JWT_SECRET_KEY=${JWT_SECRET_KEY}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD}

--- a/fe/index.html
+++ b/fe/index.html
@@ -10,6 +10,12 @@
   <link rel="icon" type="image/png" href="/favicon.png">
 </head>
 <body>
+  <script>
+    (function() {
+      var theme = localStorage.getItem('theme') || 'dark';
+      document.documentElement.setAttribute('data-theme', theme);
+    })();
+  </script>
   <div id="app"></div>
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/fe/src/locales/de.yaml
+++ b/fe/src/locales/de.yaml
@@ -199,6 +199,8 @@ character:
   noCharacter: "Kein Charakter"
   remind: "Erinnern"
   reminderSent: "Erinnerung gesendet"
+  pick: "Wählen"
+  myCharacter: "Mein Charakter"
 
 profile:
   title: "Profil Einstellungen"

--- a/fe/src/locales/en.yaml
+++ b/fe/src/locales/en.yaml
@@ -199,6 +199,8 @@ character:
   noCharacter: "No character"
   remind: "Remind"
   reminderSent: "Reminder sent"
+  pick: "Pick"
+  myCharacter: "My character"
 
 profile:
   title: "Profile Settings"

--- a/fe/src/locales/es.yaml
+++ b/fe/src/locales/es.yaml
@@ -199,6 +199,8 @@ character:
   noCharacter: "Sin personaje"
   remind: "Recordar"
   reminderSent: "Recordatorio enviado"
+  pick: "Elegir"
+  myCharacter: "Mi personaje"
 
 profile:
   title: "Configuración del Perfil"

--- a/fe/src/locales/fr.yaml
+++ b/fe/src/locales/fr.yaml
@@ -199,6 +199,8 @@ character:
   noCharacter: "Aucun personnage"
   remind: "Rappeler"
   reminderSent: "Rappel envoyé"
+  pick: "Choisir"
+  myCharacter: "Mon personnage"
 
 profile:
   title: "Paramètres du Profil"

--- a/fe/src/locales/it.yaml
+++ b/fe/src/locales/it.yaml
@@ -199,6 +199,8 @@ character:
   noCharacter: "Nessun personaggio"
   remind: "Ricorda"
   reminderSent: "Promemoria inviato"
+  pick: "Scegli"
+  myCharacter: "Il mio personaggio"
 
 profile:
   title: "Impostazioni Profilo"

--- a/fe/src/services/api.service.js
+++ b/fe/src/services/api.service.js
@@ -3,7 +3,7 @@ import { mockApi } from './mockData.service.js';
 
 const isMockMode = import.meta.env.VITE_MOCK_DATA === 'true';
 
-const baseURL = (import.meta.env.VITE_API_URL || 'http://localhost:5000').replace(/\/+$/, '');
+const baseURL = (import.meta.env.VITE_API_URL || 'http://localhost:5000').replace(/\/+$/, '') + '/api';
 
 const apiService = axios.create({
   baseURL: baseURL,

--- a/fe/src/stores/campaigns.store.js
+++ b/fe/src/stores/campaigns.store.js
@@ -7,6 +7,7 @@ export const useCampaignsStore = defineStore('campaigns', () => {
   const sharedCampaigns = ref([]);
   const currentCampaign = ref(null);
   const loading = ref(false);
+  const pendingCharacterCreation = ref(null);
 
   async function fetchCampaigns() {
     loading.value = true;
@@ -91,10 +92,19 @@ export const useCampaignsStore = defineStore('campaigns', () => {
     }
   }
 
+  function setPendingCharacterCreation(campaignId, mode) {
+    pendingCharacterCreation.value = { campaignId, mode };
+  }
+
+  function clearPendingCharacterCreation() {
+    pendingCharacterCreation.value = null;
+  }
+
   function $reset() {
     ownedCampaigns.value = [];
     sharedCampaigns.value = [];
     currentCampaign.value = null;
+    pendingCharacterCreation.value = null;
     loading.value = false;
   }
 
@@ -103,12 +113,15 @@ export const useCampaignsStore = defineStore('campaigns', () => {
     sharedCampaigns,
     currentCampaign,
     loading,
+    pendingCharacterCreation,
     fetchCampaigns,
     createCampaign,
     updateCampaign,
     deleteCampaign,
     setCurrentCampaign,
     addSharedCampaign,
+    setPendingCharacterCreation,
+    clearPendingCharacterCreation,
     $reset
   };
 });

--- a/fe/src/stores/invites.store.js
+++ b/fe/src/stores/invites.store.js
@@ -27,7 +27,7 @@ export const useInvitesStore = defineStore('invites', () => {
       
       invites.value = invites.value.filter(inv => inv.id !== inviteId);
       
-      return { success: true, campaign: response.data };
+      return { success: true, campaign: response.data.campaign };
     } catch (error) {
       return { 
         success: false, 

--- a/fe/src/style.css
+++ b/fe/src/style.css
@@ -16,26 +16,28 @@
     --placeholder-color: #6a6a6a;
     --hover-bg: rgba(60, 60, 60, 0.4);
     --success-color: #4caf50;
+    --primary-color: #a88958;
 }
 
 :root[data-theme="light"] {
-    --bg-gradient-1: #f5ebe0;
-    --bg-gradient-2: #e8dcc8;
-    --bg-primary: #f5ebe0;
-    --text-primary: #3a2f26;
-    --text-secondary: #6b5d4f;
-    --text-heading: #8b6f47;
-    --card-bg-1: rgba(255, 250, 240, 0.9);
-    --card-bg-2: rgba(250, 245, 235, 0.95);
-    --input-bg: rgba(255, 255, 255, 0.8);
-    --input-border: #d4c5b9;
-    --border-color: #d4c5b9;
-    --button-secondary-bg: rgba(228, 218, 203, 0.8);
-    --button-secondary-border: #c9b89a;
-    --button-secondary-hover: rgba(212, 197, 185, 0.9);
-    --placeholder-color: #9a8575;
-    --hover-bg: rgba(228, 218, 203, 0.5);
-    --success-color: #4caf50;
+    --bg-gradient-1: #ede0d0;
+    --bg-gradient-2: #d9c9b0;
+    --bg-primary: #ede0d0;
+    --text-primary: #2a1f16;
+    --text-secondary: #5a4d42;
+    --text-heading: #6b4f2a;
+    --card-bg-1: rgba(255, 248, 235, 0.95);
+    --card-bg-2: rgba(245, 236, 218, 0.98);
+    --input-bg: rgba(255, 255, 255, 0.9);
+    --input-border: #b8a48a;
+    --border-color: #b8a48a;
+    --button-secondary-bg: rgba(210, 195, 172, 0.9);
+    --button-secondary-border: #a89070;
+    --button-secondary-hover: rgba(192, 174, 148, 1);
+    --placeholder-color: #8a7060;
+    --hover-bg: rgba(210, 195, 172, 0.6);
+    --success-color: #3d8b40;
+    --primary-color: #8b6f47;
 }
 
 :root {

--- a/fe/src/style.css
+++ b/fe/src/style.css
@@ -3286,6 +3286,28 @@ input::placeholder, textarea::placeholder {
     margin-top: 0.25rem;
 }
 
+.my-character-badge {
+    font-size: 0.75rem;
+    color: var(--accent-gold-3);
+    font-weight: 600;
+    margin-top: 0.25rem;
+}
+
+.pick-btn {
+    padding: 0.25rem 0.6rem;
+    font-size: 0.75rem;
+    background: linear-gradient(135deg, var(--accent-gold-1), var(--accent-gold-2));
+    color: #f5e6d3;
+    border: 1px solid var(--accent-gold-2);
+    border-radius: 4px;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.pick-btn:hover {
+    background: linear-gradient(135deg, var(--accent-gold-2), var(--accent-gold-3));
+}
+
 /* PredefinedCharactersManager.vue styles */
 .predefined-characters-manager {
     display: flex;

--- a/fe/src/views/Home.vue
+++ b/fe/src/views/Home.vue
@@ -227,9 +227,16 @@ watch(searchQuery, (newValue) => {
 watch(() => campaignsStore.currentCampaign, async (newCampaign) => {
   if (newCampaign) {
     fetchViewedStatus();
-    checkPendingCharacterCreation();
   } else {
     showCharacterNotification.value = false;
+  }
+});
+
+watch(() => campaignsStore.pendingCharacterCreation, (pending) => {
+  if (pending) {
+    notificationMode.value = pending.mode;
+    showCharacterNotification.value = true;
+    campaignsStore.clearPendingCharacterCreation();
   }
 });
 

--- a/fe/src/views/Home.vue
+++ b/fe/src/views/Home.vue
@@ -5,6 +5,7 @@
         <HamburgerMenu ref="hamburgerMenu" @invites-sent="handleInvitesSent" class="mobile-only"/>
         <h1>{{ t('app.title') }}</h1>
         <div class="user-info flex-align-center">
+          <ThemeToggle/>
           <NotificationBell/>
           <div class="user-avatar clickable" @click="showProfileModal = true">
             <img v-if="authStore.user?.avatar_url" 

--- a/fe/src/views/components/left/CampaignPlayersPanel.vue
+++ b/fe/src/views/components/left/CampaignPlayersPanel.vue
@@ -207,10 +207,12 @@ function hasCharacter(userId) {
   return characters.value.some(c => c.assigned_to_user_id === userId);
 }
 
-function handleSendReminder(member) {
-  // This would ideally send a notification to the player
-  // For now, we'll just show a message
-  alert(`${t('character.reminderSent')} ${member.username}`);
+async function handleSendReminder(member) {
+  try {
+    await api.post(`/campaigns/${campaignsStore.currentCampaign.id}/members/${member.id}/remind`);
+  } catch (error) {
+    alert(error.response?.data?.error || t('common.error'));
+  }
 }
 
 defineExpose({

--- a/fe/src/views/components/left/CampaignPlayersPanel.vue
+++ b/fe/src/views/components/left/CampaignPlayersPanel.vue
@@ -108,7 +108,6 @@ const authStore = useAuthStore();
 
 const members = ref([]);
 const pendingInvites = ref([]);
-const characters = ref([]);
 const loading = ref(false);
 const showRemoveMemberConfirm = ref(false);
 const showCancelInviteConfirm = ref(false);
@@ -145,11 +144,7 @@ async function fetchMembers() {
     members.value = response.data.members || [];
     pendingInvites.value = response.data.pending_invites || [];
     
-    // Fetch characters to check assignments
-    const charsResponse = await charactersStore.fetchCharacters(campaignsStore.currentCampaign.id);
-    if (charsResponse) {
-      characters.value = charactersStore.characters;
-    }
+    await charactersStore.fetchCharacters(campaignsStore.currentCampaign.id);
   } catch (error) {
     console.error('Failed to fetch campaign members:', error);
   } finally {
@@ -204,7 +199,7 @@ function toggleCollapse() {
 }
 
 function hasCharacter(userId) {
-  return characters.value.some(c => c.assigned_to_user_id === userId);
+  return charactersStore.characters.some(c => c.assigned_to_user_id === userId);
 }
 
 async function handleSendReminder(member) {

--- a/fe/src/views/components/left/characters/CampaignCharactersPanel.vue
+++ b/fe/src/views/components/left/characters/CampaignCharactersPanel.vue
@@ -4,7 +4,7 @@
       <div class="panel-header flex-between">
         <h3>{{ t('character.characters') }}</h3>
         <span
-            v-if="isCurrentCampaignOwned"
+            v-if="canCreateCharacter"
             @click="openCreateModal"
             class="btn-circle"
             :title="t('character.createTooltip')"
@@ -47,9 +47,22 @@
               <span class="character-name">{{ character.name }}</span>
               <span class="character-race">{{ character.race }}</span>
               <span class="character-class">{{ character.character_class }}</span>
-              <span v-if="character.assigned_to_user_id" class="character-assigned">
+              <span v-if="character.assigned_to_user_id === currentUserId" class="my-character-badge">
+                {{ t('character.myCharacter') }}
+              </span>
+              <span v-else-if="character.assigned_to_user_id" class="character-assigned">
                 {{ t('character.assignedTo') }}
               </span>
+            </div>
+
+            <div class="character-actions" @click.stop>
+              <button
+                  v-if="canPickCharacter(character)"
+                  @click.stop="handlePickCharacter(character)"
+                  class="pick-btn btn-sm"
+              >
+                {{ t('character.pick') }}
+              </button>
             </div>
 
             <div v-if="isCurrentCampaignOwned" class="character-actions" @click.stop>
@@ -163,6 +176,21 @@ const isCurrentCampaignOwned = computed(() => {
       campaign => campaign.id === campaignsStore.currentCampaign.id
   );
 });
+
+const currentUserId = computed(() => authStore.user?.id);
+
+const campaignMode = computed(() => campaignsStore.currentCampaign?.character_creation_mode);
+
+const canCreateCharacter = computed(() => {
+  if (!campaignsStore.currentCampaign) return false;
+  if (isCurrentCampaignOwned.value) return true;
+  return campaignMode.value === 'free' || campaignMode.value === 'optional';
+});
+
+function canPickCharacter(character) {
+  if (isCurrentCampaignOwned.value) return false;
+  return character.is_predefined && !character.assigned_to_user_id;
+}
 
 function getImageUrl(imageUrl) {
   if (!imageUrl) return '';
@@ -278,6 +306,19 @@ async function confirmDelete() {
     }
   }
   characterToDelete.value = null;
+}
+
+async function handlePickCharacter(character) {
+  const result = await charactersStore.assignCharacterToUser(
+    campaignsStore.currentCampaign.id,
+    character.id,
+    null
+  );
+  if (result.success) {
+    charactersStore.fetchCharacters(campaignsStore.currentCampaign.id);
+  } else {
+    alert(result.error || t('common.error'));
+  }
 }
 
 function handleClickOutside(event) {

--- a/fe/src/views/components/up/NotificationBell.vue
+++ b/fe/src/views/components/up/NotificationBell.vue
@@ -132,7 +132,6 @@ async function handleAccept(notification) {
     const result = await invitesStore.acceptInvite(inviteId);
     if (result.success) {
       campaignsStore.addSharedCampaign(result.campaign);
-      campaignsStore.setCurrentCampaign(result.campaign);
       notifications.value = notifications.value.filter(n => n.id !== notification.id);
 
       const mode = result.campaign.character_creation_mode;
@@ -142,6 +141,8 @@ async function handleAccept(notification) {
           mode: mode
         }));
       }
+
+      campaignsStore.setCurrentCampaign(result.campaign);
     }
   }
 }

--- a/fe/src/views/components/up/NotificationBell.vue
+++ b/fe/src/views/components/up/NotificationBell.vue
@@ -132,8 +132,9 @@ async function handleAccept(notification) {
     const result = await invitesStore.acceptInvite(inviteId);
     if (result.success) {
       campaignsStore.addSharedCampaign(result.campaign);
+      campaignsStore.setCurrentCampaign(result.campaign);
       notifications.value = notifications.value.filter(n => n.id !== notification.id);
-      
+
       const mode = result.campaign.character_creation_mode;
       if (mode === 'free' || mode === 'predefined') {
         sessionStorage.setItem('pendingCharacterCreation', JSON.stringify({

--- a/fe/src/views/components/up/NotificationBell.vue
+++ b/fe/src/views/components/up/NotificationBell.vue
@@ -136,12 +136,8 @@ async function handleAccept(notification) {
 
       const mode = result.campaign.character_creation_mode;
       if (mode === 'free' || mode === 'predefined') {
-        sessionStorage.setItem('pendingCharacterCreation', JSON.stringify({
-          campaignId: result.campaign.id,
-          mode: mode
-        }));
+        campaignsStore.setPendingCharacterCreation(result.campaign.id, mode);
       }
-
       campaignsStore.setCurrentCampaign(result.campaign);
     }
   }
@@ -157,6 +153,16 @@ async function handleReject(notification) {
 
 function handleNotificationClick(notification) {
   showDropdown.value = false;
+
+  if (notification.notification_type === 'character_reminder' && notification.campaign_id) {
+    const campaign = [...campaignsStore.sharedCampaigns, ...campaignsStore.ownedCampaigns]
+      .find(c => c.id === notification.campaign_id);
+    if (campaign && campaign.character_creation_mode !== 'optional') {
+      campaignsStore.setPendingCharacterCreation(campaign.id, campaign.character_creation_mode);
+      campaignsStore.setCurrentCampaign(campaign);
+    }
+    return;
+  }
 
   if (notification.related_post_id) {
     const route = {name: 'home'};


### PR DESCRIPTION
## Summary

- **Backend startup**: replaced `eventlet` with `threading` async mode (incompatible with Python 3.14); added `allow_unsafe_werkzeug=True` so the dev server actually starts
- **DB/deps**: migrated from `psycopg2` to `psycopg` v3; fixed standalone Docker volume mount for init SQL
- **Campaign model**: added missing `members` relationship; removed duplicate that caused a crash on startup
- **Invite flow**: fixed `accept_invite` returning silently without creating the `CampaignMember` record (500 on accept); fixed `sessionStorage` race condition where campaign wasn't set before navigation; fixed character selection never triggering after invite acceptance
- **Character system**: players can now create their own characters (auto-assigned to creator) and pick unassigned predefined characters; campaign owner (DM) can also pick unassigned predefined characters (was incorrectly blocked by frontend guard); predefined character creation remains restricted to campaign owner
- **Players panel**: fixed `hasCharacter()` always returning false (was reading from a stale local ref instead of the Pinia store)
- **User profile**: `update_profile` no longer wipes `avatar_url` when the field is absent from the request
- **Tests**: updated 2 stale unit tests to match current service behaviour

## Test plan

- [x] Backend: all 71 tests pass (`pytest -q` from `be/`)
- [x] Frontend build succeeds (`npm ci && npm run build` from `fe/`)
- [x] Full invite flow: owner creates campaign → invites player → player accepts → character selection triggered
- [x] Player creates character → auto-assigned to player
- [x] Player picks predefined character → assigned correctly
- [x] DM picks predefined character → now works (was blocked)
- [x] REMIND button shown for players without a character
- [x] Avatar preserved after profile-only update