### PR TITLE
feat(dndbook) [#15] add CampaignResourcesAndTools panel

### DIFF
--- a/fe/src/locales/en.yaml
+++ b/fe/src/locales/en.yaml
@@ -75,7 +75,9 @@ campaign:
   modeFreeDesc: "Players must create their own character to join"
   modePredefined: "Predefined Characters"
   modePredefinedDesc: "Players select from predefined characters created by the master"
-  
+  resourcesTitle: "Resources & Tools"
+  resourcesEmpty: "No resources yet."
+
 post:
   createPost: "Create Post"
   title: "Post title..."
@@ -162,6 +164,7 @@ common:
   confirm: "Confirm"
   cancel: "Cancel"
   later: "Later"
+  close: "Close"
 
 character:
   characters: "Characters"

--- a/fe/src/locales/it.yaml
+++ b/fe/src/locales/it.yaml
@@ -75,7 +75,9 @@ campaign:
   modeFreeDesc: "I giocatori devono creare il proprio personaggio per entrare"
   modePredefined: "Personaggi Predefiniti"
   modePredefinedDesc: "I giocatori selezionano tra i personaggi predefiniti creati dal master"
-  
+  resourcesTitle: "Risorse e Strumenti"
+  resourcesEmpty: "Nessuna risorsa ancora."
+
 post:
   createPost: "Crea Post"
   title: "Titolo del post..."
@@ -162,6 +164,7 @@ common:
   confirm: "Conferma"
   cancel: "Annulla"
   later: "Più tardi"
+  close: "Chiudi"
 
 character:
   characters: "Personaggi"

--- a/fe/src/style.css
+++ b/fe/src/style.css
@@ -2302,6 +2302,20 @@ input::placeholder, textarea::placeholder {
     margin-left: 0;
 }
 
+.sidebar-header-left {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.resources-toggle-btn {
+    opacity: 0.6;
+}
+
+.resources-toggle-btn:hover {
+    opacity: 1;
+}
+
 .campaign-header .campaign-menu-container {
     margin-left: auto;
 }

--- a/fe/src/views/components/right/CampaignResourcesAndTools.vue
+++ b/fe/src/views/components/right/CampaignResourcesAndTools.vue
@@ -1,0 +1,127 @@
+<template>
+  <Teleport to="body">
+    <Transition name="fade">
+      <div
+        v-if="show"
+        class="resources-backdrop"
+        @click="$emit('close')"
+      />
+    </Transition>
+    <Transition name="slide-panel">
+      <div
+        v-if="show"
+        class="resources-panel"
+        role="dialog"
+        aria-modal="true"
+        :aria-label="t('campaign.resourcesTitle')"
+      >
+        <div class="resources-panel-header flex-between">
+          <h3>{{ t('campaign.resourcesTitle') }}</h3>
+          <button class="menu-toggle-btn" @click="$emit('close')" :title="t('common.close')">✕</button>
+        </div>
+        <div class="resources-panel-body">
+          <p class="resources-empty">{{ t('campaign.resourcesEmpty') }}</p>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { onUnmounted, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+
+const props = defineProps({
+  show: {
+    type: Boolean,
+    default: false
+  }
+});
+
+const emit = defineEmits(['close']);
+
+function onKeydown(e) {
+  if (e.key === 'Escape') emit('close');
+}
+
+watch(() => props.show, (val) => {
+  if (val) {
+    document.addEventListener('keydown', onKeydown);
+  } else {
+    document.removeEventListener('keydown', onKeydown);
+  }
+});
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', onKeydown);
+});
+</script>
+
+<style scoped>
+.resources-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 900;
+}
+
+.resources-panel {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 300px;
+  height: 100vh;
+  background: linear-gradient(145deg, var(--card-bg-1) 0%, var(--card-bg-2) 100%);
+  border-right: 1px solid rgba(139, 111, 71, 0.3);
+  box-shadow: 4px 0 16px rgba(0, 0, 0, 0.3);
+  z-index: 901;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.resources-panel-header {
+  padding: 16px;
+  border-bottom: 1px solid rgba(139, 111, 71, 0.2);
+  flex-shrink: 0;
+}
+
+.resources-panel-header h3 {
+  font-size: 16px;
+}
+
+.resources-panel-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.resources-empty {
+  color: var(--text-secondary);
+  font-style: italic;
+  font-size: 14px;
+}
+
+/* transitions */
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.slide-panel-enter-active,
+.slide-panel-leave-active {
+  transition: transform 0.3s ease;
+}
+.slide-panel-enter-from,
+.slide-panel-leave-to {
+  transform: translateX(-100%);
+}
+</style>

--- a/fe/src/views/components/right/tree/CampaignsTree.vue
+++ b/fe/src/views/components/right/tree/CampaignsTree.vue
@@ -1,7 +1,14 @@
 <template>
   <div class="sidebar">
     <div class="sidebar-header flex-between">
-      <h2>{{ t('campaign.campaigns') }}</h2>
+      <div class="sidebar-header-left flex-align-center">
+        <button
+          class="menu-toggle-btn resources-toggle-btn"
+          @click="showResources = true"
+          :title="t('campaign.resourcesTitle')"
+        >◧</button>
+        <h2>{{ t('campaign.campaigns') }}</h2>
+      </div>
       <div class="campaign-menu-container">
         <button 
             ref="actionsMenuButton"
@@ -76,6 +83,11 @@
         @confirm="handleExportConfirm"
         @cancel="showExportConfirm = false"
     />
+
+    <CampaignResourcesAndTools
+        :show="showResources"
+        @close="showResources = false"
+    />
   </div>
 </template>
 
@@ -90,12 +102,14 @@ import CampaignImportModal from '../../modals/CampaignImportModal.vue';
 import ConfirmModal from '../../modals/ConfirmModal.vue';
 import OwnedCampaignsTree from './OwnedCampaignsTree.vue';
 import SharedCampaignsTree from './SharedCampaignsTree.vue';
+import CampaignResourcesAndTools from '../CampaignResourcesAndTools.vue';
 import axios from 'axios';
 
 const {t} = useI18n();
 const campaignsStore = useCampaignsStore();
 const postsStore = usePostsStore();
 
+const showResources = ref(false);
 const expandedCampaignId = ref(null);
 const showCreateModal = ref(false);
 const showInviteModal = ref(false);


### PR DESCRIPTION
Closes #15.

Adds a toggle button on the left side of the CampaignsTree header. Clicking it opens a left slide-out panel (CampaignResourcesAndTools) with smooth CSS transition. Closes on Esc key or backdrop click.