### PR TITLE
feat: add Note model, CRUD API, and per-player authorization rules (#20)

### DIFF
--- a/be/app/__init__.py
+++ b/be/app/__init__.py
@@ -114,6 +114,7 @@ def create_app():
     from app.controllers import posts_viewed_status_controller as posts_viewed_status
     from app.controllers import notifications_controller as notifications
     from app.controllers import user_controller as user
+    from app.controllers import notes_controller as notes
     from app.controllers import pdf_export_controller as pdf_export
     from app.events import socketio_events
 
@@ -127,6 +128,7 @@ def create_app():
     app.register_blueprint(posts_viewed_status.bp)
     app.register_blueprint(notifications.bp)
     app.register_blueprint(user.bp)
+    app.register_blueprint(notes.bp)
     app.register_blueprint(pdf_export.bp)
 
     @app.route('/uploads/<path:filename>')

--- a/be/app/controllers/notes_controller.py
+++ b/be/app/controllers/notes_controller.py
@@ -1,0 +1,191 @@
+"""Controller for note CRUD endpoints with authorization."""
+
+from flask import Blueprint, request, jsonify
+
+from app.jwt.jwt_utils import token_required
+from app.services.notes_service import NotesService
+
+bp = Blueprint("notes", __name__, url_prefix="/api")
+
+
+@bp.route("/campaigns/<int:campaign_id>/notes", methods=["GET"])
+@token_required
+def get_notes(current_user, campaign_id):
+    """Get notes visible to the current user in a campaign.
+
+    DM/owner sees all notes; players see only notes they are permitted to view.
+
+    Args:
+        current_user: Authenticated user (injected by token_required)
+        campaign_id (int): Campaign ID
+
+    Returns:
+        200: List of visible notes
+        403: User is not authorized to access this campaign
+        404: Campaign not found
+    """
+    try:
+        notes = NotesService.get_notes(campaign_id, current_user)
+        return jsonify(notes), 200
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 403
+
+
+@bp.route("/campaigns/<int:campaign_id>/notes", methods=["POST"])
+@token_required
+def create_note(current_user, campaign_id):
+    """Create a new note. Only campaign owner (DM) can create notes.
+
+    Expected JSON payload:
+        - title (str): Note title (required)
+        - content (str): Markdown content (optional)
+        - visibility (str): "personal" or "players" (optional, default: "personal")
+        - parent_id (int): Parent note ID for nesting (optional)
+
+    Args:
+        current_user: Authenticated user
+        campaign_id (int): Campaign ID
+
+    Returns:
+        201: Created note data
+        400: Missing or invalid fields
+        403: User is not authorized
+    """
+    data = request.get_json() or {}
+
+    if not data.get("title"):
+        return jsonify({"error": "Title is required"}), 400
+
+    try:
+        note = NotesService.create_note(
+            user=current_user,
+            campaign_id=campaign_id,
+            title=data["title"],
+            content=data.get("content", ""),
+            visibility=data.get("visibility", "personal"),
+            parent_id=data.get("parent_id"),
+        )
+        return jsonify(note.to_dict(user=current_user)), 201
+    except ValueError as e:
+        if any(x in str(e) for x in ("Title", "visibility", "Parent")):
+            return jsonify({"error": str(e)}), 400
+        return jsonify({"error": str(e)}), 403
+
+
+@bp.route("/notes/<int:note_id>", methods=["GET"])
+@token_required
+def get_note(current_user, note_id):
+    """Get a single note by ID.
+
+    Args:
+        current_user: Authenticated user
+        note_id (int): Note ID
+
+    Returns:
+        200: Note data
+        403: User is not authorized to view this note
+        404: Note not found
+    """
+    try:
+        note = NotesService.get_note(note_id, current_user)
+        return jsonify(note), 200
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 403
+
+
+@bp.route("/notes/<int:note_id>", methods=["PUT"])
+@token_required
+def update_note(current_user, note_id):
+    """Update a note. Only campaign owner (DM) can update.
+
+    Expected JSON payload:
+        - title (str): Updated title (optional)
+        - content (str): Updated markdown content (optional)
+        - visibility (str): "personal" or "players" (optional)
+        - parent_id (int): Updated parent note ID (optional)
+
+    Args:
+        current_user: Authenticated user
+        note_id (int): Note ID
+
+    Returns:
+        200: Updated note data
+        400: Invalid fields
+        403: User is not authorized
+    """
+    data = request.get_json() or {}
+
+    try:
+        note = NotesService.update_note(
+            note_id=note_id,
+            user=current_user,
+            title=data.get("title"),
+            content=data.get("content"),
+            visibility=data.get("visibility"),
+            parent_id=data.get("parent_id"),
+        )
+        return jsonify(note.to_dict(user=current_user)), 200
+    except ValueError as e:
+        if any(
+            x in str(e) for x in ("Title", "visibility", "Parent", "cannot be empty")
+        ):
+            return jsonify({"error": str(e)}), 400
+        return jsonify({"error": str(e)}), 403
+
+
+@bp.route("/notes/<int:note_id>", methods=["DELETE"])
+@token_required
+def delete_note(current_user, note_id):
+    """Delete a note. Only campaign owner (DM) can delete.
+
+    Args:
+        current_user: Authenticated user
+        note_id (int): Note ID
+
+    Returns:
+        200: Success message
+        403: User is not authorized
+    """
+    try:
+        NotesService.delete_note(note_id, current_user)
+        return jsonify({"message": "Note deleted successfully"}), 200
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 403
+
+
+@bp.route("/notes/<int:note_id>/permissions", methods=["PUT"])
+@token_required
+def set_note_permissions(current_user, note_id):
+    """Set which players can view a players-visibility note.
+
+    Only the campaign owner (DM) can set permissions.
+    Replaces any existing permission set with the provided list.
+
+    Expected JSON payload:
+        - user_ids (list): List of user IDs to grant access
+
+    Args:
+        current_user: Authenticated user
+        note_id (int): Note ID
+
+    Returns:
+        200: Updated note data
+        400: Invalid payload
+        403: User is not authorized
+    """
+    data = request.get_json() or {}
+
+    if "user_ids" not in data or not isinstance(data["user_ids"], list):
+        return jsonify({"error": "user_ids must be an array"}), 400
+
+    try:
+        note = NotesService.set_note_permissions(
+            note_id=note_id,
+            user=current_user,
+            user_ids=data["user_ids"],
+        )
+        return jsonify(note.to_dict(user=current_user)), 200
+    except ValueError as e:
+        if any(x in str(e) for x in ("not found", "not a member", "Permissions only")):
+            return jsonify({"error": str(e)}), 400
+        return jsonify({"error": str(e)}), 403

--- a/be/app/models/__init__.py
+++ b/be/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.character import Character
 from app.models.post_viewed_status import PostViewedStatus
 from app.models.notification import Notification
 from app.models.character_mention import CharacterMention
+from app.models.note import Note, note_permissions
 
 __all__ = [
     'CampaignMembers',
@@ -21,5 +22,7 @@ __all__ = [
     'Character',
     'PostViewedStatus',
     'Notification',
-    'CharacterMention'
+    'CharacterMention',
+    'Note',
+    'note_permissions',
 ]

--- a/be/app/models/note.py
+++ b/be/app/models/note.py
@@ -1,0 +1,80 @@
+"""Note model for personal and player-facing notes within campaigns."""
+
+from datetime import datetime
+
+from app import db
+
+
+class Note(db.Model):
+    """Note model representing DM notes within a campaign.
+
+    Notes can be personal (DM-only) or player-visible with per-player
+    permissions managed via the NotePermission cross-reference table.
+
+    Fields:
+        id: Primary key
+        campaign_id: Campaign this note belongs to
+        owner_id: User who created the note (always the DM/campaign owner)
+        title: Note title
+        content: Markdown body
+        visibility: 'personal' (DM-only) or 'players' (per-player gated)
+        parent_id: Optional parent note for nesting
+        created_at: Creation timestamp
+        updated_at: Last modification timestamp
+    """
+    __tablename__ = 'notes'
+
+    id = db.Column(db.Integer, primary_key=True)
+    campaign_id = db.Column(db.Integer, db.ForeignKey('campaigns.id'), nullable=False)
+    owner_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
+    title = db.Column(db.String(200), nullable=False)
+    content = db.Column(db.Text, nullable=False, default='')
+    visibility = db.Column(db.String(20), nullable=False, default='personal')
+    parent_id = db.Column(db.Integer, db.ForeignKey('notes.id'), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    owner = db.relationship('User', backref='notes', foreign_keys=[owner_id])
+    parent = db.relationship('Note', remote_side=[id], backref='children')
+    permitted_users = db.relationship(
+        'User',
+        secondary='note_permissions',
+        backref='visible_notes',
+        lazy='joined'
+    )
+
+    def to_dict(self, user=None):
+        """Convert note to dictionary for API output.
+
+        Args:
+            user: The requesting user (used to determine if permission
+                  controls should be included in the response).
+
+        Returns:
+            dict: Note data safe for the requesting user to see.
+        """
+        result = {
+            'id': self.id,
+            'campaign_id': self.campaign_id,
+            'owner_id': self.owner_id,
+            'title': self.title,
+            'content': self.content,
+            'visibility': self.visibility,
+            'parent_id': self.parent_id,
+            'created_at': self.created_at.isoformat() + 'Z',
+            'updated_at': self.updated_at.isoformat() + 'Z',
+        }
+
+        # Only DM/owner sees the permission list
+        if user is not None and self.owner_id == user.id:
+            result['permitted_user_ids'] = [u.id for u in self.permitted_users]
+
+        return result
+
+
+# Cross-reference table for per-player note visibility
+note_permissions = db.Table(
+    'note_permissions',
+    db.Column('note_id', db.Integer, db.ForeignKey('notes.id'), primary_key=True),
+    db.Column('user_id', db.Integer, db.ForeignKey('users.id'), primary_key=True),
+)

--- a/be/app/services/notes_service.py
+++ b/be/app/services/notes_service.py
@@ -1,0 +1,154 @@
+"""Service for note operations with per-player authorization."""
+
+from app import db
+from app.models import Campaign, Note, note_permissions
+from app.services.posts_service import PostsService
+
+
+class NotesService:
+    """Service for handling note CRUD and authorization."""
+
+    @staticmethod
+    def can_manage_notes(campaign, user):
+        """Check if user can manage notes (DM/owner only)."""
+        return campaign.owner_id == user.id
+
+    @staticmethod
+    def can_view_note(note, user):
+        """Check if a user can view a specific note.
+
+        Personal notes: only the owner (DM) can view.
+        Player notes: owner + explicitly permitted players can view.
+        """
+        if note.owner_id == user.id:
+            return True
+        if note.visibility == "personal":
+            return False
+        permitted_ids = {u.id for u in note.permitted_users}
+        return user.id in permitted_ids
+
+    @staticmethod
+    def get_notes(campaign_id, user):
+        """Get all notes visible to a user within a campaign."""
+        campaign = Campaign.query.get_or_404(campaign_id)
+        if not PostsService.can_access_campaign(campaign, user):
+            raise ValueError("Unauthorized")
+
+        if NotesService.can_manage_notes(campaign, user):
+            notes = Note.query.filter_by(campaign_id=campaign_id).order_by(
+                Note.created_at.desc()
+            ).all()
+        else:
+            notes = (
+                Note.query
+                .filter_by(campaign_id=campaign_id, visibility="players")
+                .filter(Note.permitted_users.any(id=user.id))
+                .order_by(Note.created_at.desc())
+                .all()
+            )
+
+        return [note.to_dict(user=user) for note in notes]
+
+    @staticmethod
+    def get_note(note_id, user):
+        """Get a single note by ID with authorization check."""
+        note = Note.query.get_or_404(note_id)
+        if not NotesService.can_view_note(note, user):
+            raise ValueError("Unauthorized")
+        return note.to_dict(user=user)
+
+    @staticmethod
+    def create_note(user, campaign_id, title, content="", visibility="personal",
+                    parent_id=None):
+        """Create a new note. Only campaign owner can create."""
+        campaign = Campaign.query.get_or_404(campaign_id)
+        if not NotesService.can_manage_notes(campaign, user):
+            raise ValueError("Unauthorized")
+        if not title:
+            raise ValueError("Title is required")
+        if visibility not in ("personal", "players"):
+            raise ValueError("visibility must be personal or players")
+        if parent_id is not None:
+            parent = Note.query.get(parent_id)
+            if parent is None or parent.campaign_id != campaign_id:
+                raise ValueError("Parent note not found in this campaign")
+
+        note = Note(
+            campaign_id=campaign_id,
+            owner_id=user.id,
+            title=title,
+            content=content,
+            visibility=visibility,
+            parent_id=parent_id,
+        )
+        db.session.add(note)
+        db.session.commit()
+        db.session.refresh(note)
+        return note
+
+    @staticmethod
+    def update_note(note_id, user, title=None, content=None, visibility=None,
+                    parent_id=None):
+        """Update a note. Only campaign owner can update."""
+        note = Note.query.get_or_404(note_id)
+        campaign = Campaign.query.get(note.campaign_id)
+        if not NotesService.can_manage_notes(campaign, user):
+            raise ValueError("Unauthorized")
+
+        if title is not None:
+            if not title:
+                raise ValueError("Title cannot be empty")
+            note.title = title
+        if content is not None:
+            note.content = content
+        if visibility is not None:
+            if visibility not in ("personal", "players"):
+                raise ValueError("visibility must be personal or players")
+            note.visibility = visibility
+        if parent_id is not None:
+            parent = Note.query.get(parent_id)
+            if parent is None or parent.campaign_id != note.campaign_id:
+                raise ValueError("Parent note not found")
+            note.parent_id = parent_id
+
+        db.session.commit()
+        return note
+
+    @staticmethod
+    def delete_note(note_id, user):
+        """Delete a note. Only campaign owner can delete."""
+        note = Note.query.get_or_404(note_id)
+        campaign = Campaign.query.get(note.campaign_id)
+        if not NotesService.can_manage_notes(campaign, user):
+            raise ValueError("Unauthorized")
+        db.session.delete(note)
+        db.session.commit()
+
+    @staticmethod
+    def set_note_permissions(note_id, user, user_ids):
+        """Set which players can view a players-visibility note.
+
+        Only the campaign owner (DM) can set permissions.
+        Replaces existing permissions with the given user list.
+        """
+        note = Note.query.get_or_404(note_id)
+        campaign = Campaign.query.get(note.campaign_id)
+        if not NotesService.can_manage_notes(campaign, user):
+            raise ValueError("Unauthorized")
+        if note.visibility != "players":
+            raise ValueError("Permissions only for players-visibility notes")
+
+        from app.models import User as UserModel
+        users = UserModel.query.filter(UserModel.id.in_(user_ids)).all()
+        found_ids = {u.id for u in users}
+
+        for uid in user_ids:
+            if uid not in found_ids:
+                raise ValueError(f"User {uid} not found")
+            is_member = campaign.members.filter_by(id=uid).first() is not None
+            if uid != campaign.owner_id and not is_member:
+                raise ValueError(f"User {uid} is not a campaign member")
+
+        note.permitted_users = users
+        db.session.commit()
+        return note

--- a/be/tests/services/test_notes_service.py
+++ b/be/tests/services/test_notes_service.py
@@ -1,0 +1,189 @@
+"""Unit tests for NotesService using GIVEN-WHEN-THEN pattern."""
+
+import pytest
+from app import db
+from app.services.notes_service import NotesService
+from app.models import Campaign, User, Note
+
+
+def test_create_note_as_owner(app):
+    with app.app_context():
+        owner = User(username="owner", email="owner@example.com")
+        owner.set_password("password123")
+        db.session.add(owner)
+        db.session.commit()
+
+        campaign = Campaign(
+            name="Test Campaign",
+            description="Test description",
+            owner_id=owner.id,
+            character_creation_mode="optional",
+        )
+        db.session.add(campaign)
+        db.session.commit()
+
+        note = NotesService.create_note(
+            user=owner,
+            campaign_id=campaign.id,
+            title="DM Secret",
+            content="Hidden details",
+            visibility="personal",
+        )
+
+        assert note is not None
+        assert note.title == "DM Secret"
+        assert note.visibility == "personal"
+        assert note.owner_id == owner.id
+
+
+def test_create_note_unauthorized(app):
+    with app.app_context():
+        owner = User(username="owner", email="owner@example.com")
+        owner.set_password("password123")
+        db.session.add(owner)
+        other = User(username="player", email="player@example.com")
+        other.set_password("password123")
+        db.session.add(other)
+        db.session.commit()
+
+        campaign = Campaign(name="Test", owner_id=owner.id, character_creation_mode="optional")
+        db.session.add(campaign)
+        db.session.commit()
+
+        with pytest.raises(ValueError, match="Unauthorized"):
+            NotesService.create_note(user=other, campaign_id=campaign.id, title="X")
+
+
+def test_create_note_invalid_visibility(app):
+    with app.app_context():
+        owner = User(username="owner", email="owner@example.com")
+        owner.set_password("password123")
+        db.session.add(owner)
+        db.session.commit()
+
+        campaign = Campaign(name="Test", owner_id=owner.id, character_creation_mode="optional")
+        db.session.add(campaign)
+        db.session.commit()
+
+        with pytest.raises(ValueError, match="visibility must be"):
+            NotesService.create_note(user=owner, campaign_id=campaign.id, title="X", visibility="public")
+
+
+def test_get_notes_dm_sees_all(app):
+    with app.app_context():
+        owner = User(username="owner", email="owner@example.com")
+        owner.set_password("password123")
+        db.session.add(owner)
+        db.session.commit()
+
+        campaign = Campaign(name="Test", owner_id=owner.id, character_creation_mode="optional")
+        db.session.add(campaign)
+        db.session.commit()
+
+        NotesService.create_note(owner, campaign.id, "Personal", visibility="personal")
+        NotesService.create_note(owner, campaign.id, "Player", visibility="players")
+
+        notes = NotesService.get_notes(campaign.id, owner)
+        assert len(notes) == 2
+
+
+def test_get_notes_player_permitted(app):
+    with app.app_context():
+        owner = User(username="owner", email="owner@example.com")
+        owner.set_password("password123")
+        db.session.add(owner)
+        player = User(username="player", email="player@example.com")
+        player.set_password("password123")
+        db.session.add(player)
+        db.session.commit()
+
+        campaign = Campaign(name="Test", owner_id=owner.id, character_creation_mode="optional")
+        db.session.add(campaign)
+        campaign.members.append(player)
+        db.session.commit()
+
+        pnote = NotesService.create_note(owner, campaign.id, "For Players", visibility="players")
+        NotesService.create_note(owner, campaign.id, "DM Secret", visibility="personal")
+        NotesService.set_note_permissions(pnote.id, owner, [player.id])
+
+        notes = NotesService.get_notes(campaign.id, player)
+        assert len(notes) == 1
+        assert notes[0]["title"] == "For Players"
+
+
+def test_get_note_unauthorized(app):
+    with app.app_context():
+        owner = User(username="owner", email="owner@example.com")
+        owner.set_password("password123")
+        db.session.add(owner)
+        other = User(username="other", email="other@example.com")
+        other.set_password("password123")
+        db.session.add(other)
+        db.session.commit()
+
+        campaign = Campaign(name="Test", owner_id=owner.id, character_creation_mode="optional")
+        db.session.add(campaign)
+        db.session.commit()
+
+        note = NotesService.create_note(owner, campaign.id, "Secret", visibility="personal")
+        with pytest.raises(ValueError, match="Unauthorized"):
+            NotesService.get_note(note.id, other)
+
+
+def test_update_note(app):
+    with app.app_context():
+        owner = User(username="owner", email="owner@example.com")
+        owner.set_password("password123")
+        db.session.add(owner)
+        db.session.commit()
+
+        campaign = Campaign(name="Test", owner_id=owner.id, character_creation_mode="optional")
+        db.session.add(campaign)
+        db.session.commit()
+
+        note = NotesService.create_note(owner, campaign.id, "Original")
+        updated = NotesService.update_note(note.id, owner, title="Updated", content="New content")
+
+        assert updated.title == "Updated"
+        assert updated.content == "New content"
+
+
+def test_delete_note(app):
+    with app.app_context():
+        owner = User(username="owner", email="owner@example.com")
+        owner.set_password("password123")
+        db.session.add(owner)
+        db.session.commit()
+
+        campaign = Campaign(name="Test", owner_id=owner.id, character_creation_mode="optional")
+        db.session.add(campaign)
+        db.session.commit()
+
+        note = NotesService.create_note(owner, campaign.id, "To Delete")
+        NotesService.delete_note(note.id, owner)
+        assert Note.query.get(note.id) is None
+
+
+def test_to_dict_no_permissions_for_players(app):
+    with app.app_context():
+        owner = User(username="owner", email="owner@example.com")
+        owner.set_password("password123")
+        db.session.add(owner)
+        player = User(username="player", email="player@example.com")
+        player.set_password("password123")
+        db.session.add(player)
+        db.session.commit()
+
+        campaign = Campaign(name="Test", owner_id=owner.id, character_creation_mode="optional")
+        db.session.add(campaign)
+        campaign.members.append(player)
+        db.session.commit()
+
+        pnote = NotesService.create_note(owner, campaign.id, "Player", visibility="players")
+        NotesService.set_note_permissions(pnote.id, owner, [player.id])
+
+        pd = pnote.to_dict(user=player)
+        assert "permitted_user_ids" not in pd
+
+        od = pnote.to_dict(user=owner)
+        assert "permitted_user_ids" in od


### PR DESCRIPTION
Closes #20

## Summary

Adds the Note model, CRUD API endpoints, and server-side authorization rules for per-player note visibility in campaigns.

## Changes

### Backend (be/)

- **New model**: `Note` with fields for id, campaign, owner, title, content, visibility (`personal` or `players`), parent_id, and timestamps. The `note_permissions` cross-reference table links notes to permitted users.
- **New service**: `NotesService` with authorization-aware CRUD:
  - `can_manage_notes` — only the campaign owner (DM) can create/update/delete notes
  - `can_view_note` — DM sees all; players see only notes with `visibility='players'` that they are explicitly permitted to view
  - `get_notes` — DM sees all campaign notes; players see only their permitted subset
  - `set_note_permissions` — DM assigns which players can see a note (replaces membership)
  - `to_dict` — the `permitted_user_ids` field is only included for the DM owner
- **New controller**: REST endpoints following existing project patterns:
  - `GET /api/campaigns/:id/notes` — list visible notes
  - `POST /api/campaigns/:id/notes` — create note (DM only)
  - `GET /api/notes/:id` — single note
  - `PUT /api/notes/:id` — update note (DM only)
  - `DELETE /api/notes/:id` — delete note (DM only)
  - `PUT /api/notes/:id/permissions` — set player access (DM only)
- **Tests**: 9 integration tests covering creation, authorization, visibility filtering, permission management, update, delete, and info hiding
- **Registration**: Note model, blueprints registered in app factory and model init

## Verification

- All project Python files pass `py_compile` syntax check
- Integration test verified manually: DM creates personal + player notes, grants per-player access, players see only permitted notes, unauthorized access correctly denied, info hiding works

## Notes

- Frontend integration for hiding UI controls (AC #20 item 1) is a separate follow-up once the frontend note components (#16, #17) are built
- The Note model follows the spec from #18 (id, title, content, ownerId, visibility, timestamps, parentId) and adds the authorization layer from #20
